### PR TITLE
fix: correct documentation link in README for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A RESTful API for managing blog posts, users, and comments. This project provides endpoints for creating, reading, updating, and deleting blog content, as well as user authentication and authorization.
 
-For detailed setup instructions and API reference, see [documentation.md](./documentation.md).
+For detailed setup instructions and API reference, see [documentation.md](./docs/documentation.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the link to the API documentation to point to the correct location, ensuring readers can access the latest API guide without broken links. The hyperlink now correctly routes to the consolidated docs section, improving discoverability for new users and contributors. No application behavior is affected, but documentation navigation is clearer and reduces confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->